### PR TITLE
Added onFocus and className props for modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Optional prop:
 - `disableHorizontalResize` to disable the horizontal resize function(default false).
 - `disableVerticalMove` to disable the vertical drop function(default false).
 - `disableHorizontalMove` to disable the horizontal drop function(default false).
+- `onFocus` called when the modal is clicked.
+- `className` The additional class to the modal.
 
 
 Example:
@@ -97,6 +99,8 @@ Example:
 <Modal
   isOpen={bool}
   onRequestClose={this.closeModal}
+  onFocus={() => console.log("Modal is clicked")}
+  className={"my-modal-custom-class"}
   initWidth={800} 
   initHeight={400}
 >
@@ -145,7 +149,11 @@ class App extends Component {
                 >
                     Open modal
                 </button>
-                <ReactModal initWidth={800} initHeight={400} onRequestClose={this.closeModal} isOpen={this.state.modalIsOpen}>
+                <ReactModal initWidth={800} initHeight={400} 
+                onFocus={() => console.log("Modal is clicked")}
+                className={"my-modal-custom-class"}
+                onRequestClose={this.closeModal} 
+                isOpen={this.state.modalIsOpen}>
                     <h3>My Modal</h3>
                     <div className="body">
                         <p>This is the modal&apos;s body.</p>

--- a/src/index.js
+++ b/src/index.js
@@ -7,17 +7,18 @@ import { CSSTransition } from 'react-transition-group';
 
 class Modal extends Component {
 	render() {
-		const { isDragging, width, height, top, left, isOpen, isMinimised, onRequestRecover } = this.props;
+		const { isDragging, width, height, top, left, isOpen, isMinimised, onRequestRecover,className,onFocus } = this.props;
 		if (isOpen) {
 			return (
 				<Fragment>
 					<CSSTransition in={!isMinimised} timeout={300} classNames="minimise" unmountOnExit>
 						<div
+							onClick={onFocus}
 							ref={(node) => {
 								this.node = node;
 							}}
 							draggable={isDragging}
-							className="flexible-modal"
+							className={!className?"flexible-modal":"flexible-modal "+className}
 							style={{ width, height, top, left }}
 						>
 							{this.props.children}
@@ -210,7 +211,7 @@ class FlexibleModal extends Component {
 	}
 
 	render() {
-		const { isOpen, isMinimised, onRequestClose, onRequestMinimise, onRequestRecover, disableResize } = this.props;
+		const { isOpen, isMinimised, onRequestClose, onRequestMinimise, onRequestRecover, disableResize,className,onFocus } = this.props;
 		return (
 			<div>
 				{/*this mask is a must*/}
@@ -222,6 +223,8 @@ class FlexibleModal extends Component {
 					/>
 				)}
 				<Modal
+					className = {className}
+					onFocus={onFocus}
 					width={this.state.width}
 					height={this.state.height}
 					top={this.state.top}


### PR DESCRIPTION
I am currently using **multiple** modals in my application. I added `onFocus` to manage which modal is clicked to bring it to the front. Also added a `className` prop to easily change modal css class and apply different styles to different modals