### PR TITLE
add explicit children prop and make onRequestClose optional per the documentation

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,6 +2,7 @@ import { Component } from 'react';
 import './index.css';
 import Modal from './model';
 interface PropTypes {
+    children: React.JSX.Element[];
     top?: number;
     left?: number;
     initHeight?: number;
@@ -18,7 +19,7 @@ interface PropTypes {
     disableKeystroke?: boolean;
     disableVerticalResize?: boolean;
     disableHorizontalResize?: boolean;
-    onRequestClose: () => void;
+    onRequestClose?: () => void;
     onRequestMinimise?: () => void;
     onRequestRecover?: () => void;
     onFocus?: () => void;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,26 +5,27 @@ import Resizer from './resize';
 import Modal from './model';
 
 interface PropTypes {
-	top?: number;
-	left?: number;
-	initHeight?: number;
-	initWidth?: number;
-	minWidth?: number;
-	minHeight?: number;
-	isOpen: boolean;
-	className?: string;
-	disableMove?: boolean;
-	disableVerticalMove?: boolean;
-	disableHorizontalMove?: boolean;
-	isMinimised?: boolean;
-	disableResize?: boolean;
-	disableKeystroke?: boolean;
-	disableVerticalResize?: boolean;
-	disableHorizontalResize?: boolean;
-	onRequestClose: () => void;
-	onRequestMinimise?: () => void;
-	onRequestRecover?: () => void;
-	onFocus?: () => void;
+  children: React.JSX.Element[];
+  top?: number;
+  left?: number;
+  initHeight?: number;
+  initWidth?: number;
+  minWidth?: number;
+  minHeight?: number;
+  isOpen: boolean;
+  className?: string;
+  disableMove?: boolean;
+  disableVerticalMove?: boolean;
+  disableHorizontalMove?: boolean;
+  isMinimised?: boolean;
+  disableResize?: boolean;
+  disableKeystroke?: boolean;
+  disableVerticalResize?: boolean;
+  disableHorizontalResize?: boolean;
+  onRequestClose?: () => void;
+  onRequestMinimise?: () => void;
+  onRequestRecover?: () => void;
+  onFocus?: () => void;
 }
 
 


### PR DESCRIPTION
1. React functional components no longer have an implicit children property in TypeScript.
2. onRequestClose is typed as a mandatory property, whereas in your documentation it's marked as optional.